### PR TITLE
Fix missing strings and formatting in loadouts

### DIFF
--- a/tb3/loadouts.hpp
+++ b/tb3/loadouts.hpp
@@ -1,149 +1,161 @@
 //Loadouts called with: [this,"side_class","unit_class"] call tb3_fnc_Loadout;
 //Use those bellow as an example as to creating a side and unit class.
+
 class TB3_Gear {//Gear definitions stay within this.
-	class ExampleSide { //Side_class, 1st string in _this
-		class ExampleUnit { //unit_class, 2nd string in _this
-      ace_earplugs = 1; //Set to 1 to start with earplugs in
+    class ExampleSide { //Side_class, 1st string in _this
+        class ExampleUnit { //unit_class, 2nd string in _this
+            
+            ace_earplugs = 1; //Set to 1 to start with earplugs in
 
-      weapons[] = {
-        {arifle_Mk20_GL_F,
-          {"optic_Arco","acc_pointer_IR","30Rnd_556x45_Stanag","1Rnd_HE_Grenade_shell"}
-        },
-        Rangefinder
-      }; //weapons: includes binos, launchers, pistols, and main rifle/lmg weapon
+            //weapons: includes binos, launchers, pistols, and main rifle/lmg weapon
+            weapons[] = {
+                {"arifle_Mk20_GL_F",
+                    {"optic_Arco","acc_pointer_IR","30Rnd_556x45_Stanag","1Rnd_HE_Grenade_shell"}
+                },
+                "Rangefinder"
+            };
 
-			assignedItems[] = {"ItemRadio","ItemMap","ItemCompass","ItemWatch","ItemGPS"};//linked items: gps, map etc: Do not use any ACRE class names here, if you want to add an acre radio do so in a container item slot, itemRadio is auto replaced with a 343
+            //linked items: gps, map etc: Do not use any ACRE class names here, if you want to add an acre radio do so in a container item slot, itemRadio is auto replaced with a 343
+            assignedItems[] = {"ItemRadio","ItemMap","ItemCompass","ItemWatch","ItemGPS"};
 
-			headgear[] = {"H_HelmetB_plain_mcamo"};
-			goggles[] = {"G_Tactical_Black"};
-			uniform[] = {"U_B_CTRG_1"};
-				uniformContents[] = {
-					{"30Rnd_556x45_Stanag",3},// {classname,number}
-					{"SmokeShell",2},
-					{"Chemlight_green",2},
-					{"FirstAidKit",1},
-					{"ACRE_PRC148",1}
-				};
+            headgear[] = {"H_HelmetB_plain_mcamo"};
 
-			vest[] = {"V_PlateCarrierL_CTRG"};
-				vestContents[] = {
-					{"30Rnd_556x45_Stanag",5},
-					{"30Rnd_556x45_Stanag_Tracer_Red",1},
-					{"1Rnd_HE_Grenade_shell",7},
-					{"1Rnd_SmokeRed_Grenade_shell",2},
-					{"1Rnd_SmokeGreen_Grenade_shell",2},
-					{"HandGrenade",2},
-					{"Chemlight_green",4},
-					{"I_IR_Grenade",1},
-					{"FirstAidKit",1}
-				};
+            goggles[] = {"G_Tactical_Black"};
 
-			backpack[] = {"B_TacticalPack_oli"};
-				backpackContents[] = {
-					{"30Rnd_556x45_Stanag",6},
-					{"30Rnd_556x45_Stanag_Tracer_Red",2},
-					{"HandGrenade",2},
-					{"SmokeShell",2},
-					{"SmokeShellRed",2},
-					{"SmokeShellGreen",2},
-					{"I_IR_Grenade",1},
-					{"1Rnd_SmokeRed_Grenade_shell",2},
-					{"1Rnd_HE_Grenade_shell",6},
-					{"Chemlight_green",6},
-					{"FirstAidKit",2}
-				};
+            uniform[] = {"U_B_CTRG_1"};
+            uniformContents[] = {
+                {"30Rnd_556x45_Stanag",3},// {classname,number}
+                {"SmokeShell",2},
+                {"Chemlight_green",2},
+                {"FirstAidKit",1},
+                {"ACRE_PRC148",1}
+            };
 
-			magazines[] = {}; items[] = {}; // only use these if you do not want to assign gear to specific locations in containers, if you do use these ensure the magazine/item container arrays are empty.
-		};//end ExampleUnit
-		class ExampleMedic: ExampleUnit {
-      ace_medic = 1; //0, 1, or 2 sets ace medic level accordingly
+            vest[] = {"V_PlateCarrierL_CTRG"};
+            vestContents[] = {
+                {"30Rnd_556x45_Stanag",5},
+                {"30Rnd_556x45_Stanag_Tracer_Red",1},
+                {"1Rnd_HE_Grenade_shell",7},
+                {"1Rnd_SmokeRed_Grenade_shell",2},
+                {"1Rnd_SmokeGreen_Grenade_shell",2},
+                {"HandGrenade",2},
+                {"Chemlight_green",4},
+                {"I_IR_Grenade",1},
+                {"FirstAidKit",1}
+            };
+
+            backpack[] = {"B_TacticalPack_oli"};
+            backpackContents[] = {
+                {"30Rnd_556x45_Stanag",6},
+                {"30Rnd_556x45_Stanag_Tracer_Red",2},
+                {"HandGrenade",2},
+                {"SmokeShell",2},
+                {"SmokeShellRed",2},
+                {"SmokeShellGreen",2},
+                {"I_IR_Grenade",1},
+                {"1Rnd_SmokeRed_Grenade_shell",2},
+                {"1Rnd_HE_Grenade_shell",6},
+                {"Chemlight_green",6},
+                {"FirstAidKit",2}
+            };
+
+            magazines[] = {}; items[] = {}; // only use these if you do not want to assign gear to specific locations in containers, if you do use these ensure the magazine/item container arrays are empty.
+        };//end ExampleUnit
+
+        class ExampleMedic: ExampleUnit {
+            ace_medic = 1; //0, 1, or 2 sets ace medic level accordingly
+        };
+
+        class ExampleEngineer: ExampleUnit {
+            ace_engineer = 1; //0, 1, or 2 sets ace engineer level accordingly
+        };
+
+        class ExampleEOD: ExampleUnit {
+            ace_eod = 1; //0, or 1 sets ace EOD accordingly
+        };
+
+        class RandomisedUnit: ExampleUnit {
+            //Inherits all but containers, goggles, and headgear from: ExampleUnit
+            headgear[] = {"H_Booniehat_khk","H_HelmetB_plain_blk","H_HelmetB_paint","H_HelmetB_light","H_Cap_khaki_specops_UK"};
+            goggles[] = {"G_Tactical_Black","G_Bandanna_tan","G_Tactical_Clear","G_Combat","G_Lowprofile"};
+            uniform[] = {"U_B_CTRG_1","U_B_CTRG_2","U_B_CTRG_3"};
+            backpack[] = {"B_TacticalPack_oli","B_Kitbag_cbr","B_AssaultPack_cbr","B_FieldPack_khk","B_Carryall_khk"};
+            vest[] = {"V_PlateCarrierL_CTRG","V_Chestrig_oli","V_PlateCarrier1_rgr","V_BandollierB_oli"};
+
+            weapons[] = {
+            {
+                {"arifle_TRG21_GL_F",
+                    {"optic_Holosight_khk_F","acc_pointer_IR","30Rnd_556x45_Stanag","1Rnd_HE_Grenade_shell"}
+                },
+                {"arifle_TRG21_GL_F",
+                    {"optic_MRCO","acc_pointer_IR","30Rnd_556x45_Stanag","1Rnd_HE_Grenade_shell"}
+                },
+                {"arifle_Mk20_GL_plain_F",
+                    {"optic_MRCO","acc_pointer_IR","30Rnd_556x45_Stanag","1Rnd_HE_Grenade_shell"}
+                }
+            },
+            "Rangefinder"
+            };
+        };
+
+        class RandomisedUnit2: RandomisedUnit {
+            weapons[] = {
+            {"arifle_TRG21_GL_F",
+                {"optic_Holosight_khk_F","acc_pointer_IR","30Rnd_556x45_Stanag","1Rnd_HE_Grenade_shell"}
+            },
+            "Rangefinder"
+            };
+            
+            vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
+        };
+
+        class ExampleVehicle {
+            vehCargoWeapons[] = {{"launch_NLAW_F",2}};
+            vehCargoMagazines[] = {
+                {"30Rnd_556x45_Stanag",20},
+                {"30Rnd_556x45_Stanag_Tracer_Yellow",20},
+                {"200Rnd_556x45_box_red_f",4},
+                {"200Rnd_556x45_box_tracer_red_f",4},
+                {"HandGrenade",12},
+                {"SmokeShell",12},
+                {"1Rnd_HE_Grenade_shell",20}
+            };
+            vehCargoItems[] = {
+                {"FirstAidKit",15},
+                {"Medikit",1},
+                {"I_UavTerminal",1},
+                {"ToolKit",1}
+            };
+            vehCargoRucks[] = {
+                {"B_Kitbag_rgr",2,{
+                    {"30Rnd_556x45_Stanag_red",6},
+                    {"30Rnd_556x45_Stanag_Tracer_Red",2},
+                    {"HandGrenade",2},
+                    {"SmokeShell",2},
+                    {"Chemlight_green",2},
+                    {"B_IR_Grenade",1},
+                    {"200Rnd_556x45_box_red_f",2},
+                    {"200Rnd_556x45_box_tracer_red_f",2}
+                    }
+                }
+            };
+        };
+
+        class ExampleVehicle2: ExampleVehicle {
+            vehCargoRucks[] = {
+                {"B_Kitbag_rgr",2,{
+                    {"30Rnd_556x45_Stanag_red",6},
+                    {"30Rnd_556x45_Stanag_Tracer_Red",2},
+                    {"HandGrenade",2},
+                    {"SmokeShell",2},
+                    {"Chemlight_green",2},
+                    {"B_IR_Grenade",1},
+                    {"200Rnd_556x45_box_red_f",2},
+                    {"200Rnd_556x45_box_tracer_red_f",2}
+                    }
+                }
+            };
+        };
     };
-    class ExampleEngineer: ExampleUnit {
-      ace_engineer = 1; //0, 1, or 2 sets ace engineer level accordingly
-    };
-    class ExampleEOD: ExampleUnit {
-      ace_eod = 1; //0, or 1 sets ace EOD accordingly
-    };
-
-		class RandomisedUnit: ExampleUnit {
-			//Inherits all but containers, goggles, and headgear from: ExampleUnit
-			headgear[] = {"H_Booniehat_khk","H_HelmetB_plain_blk","H_HelmetB_paint","H_HelmetB_light","H_Cap_khaki_specops_UK"};
-			goggles[] = {"G_Tactical_Black","G_Bandanna_tan","G_Tactical_Clear","G_Combat","G_Lowprofile"};
-			uniform[] = {"U_B_CTRG_1","U_B_CTRG_2","U_B_CTRG_3"};
-			backpack[] = {"B_TacticalPack_oli","B_Kitbag_cbr","B_AssaultPack_cbr","B_FieldPack_khk","B_Carryall_khk"};
-			vest[] = {"V_PlateCarrierL_CTRG","V_Chestrig_oli","V_PlateCarrier1_rgr","V_BandollierB_oli"};
-
-      weapons[] = {
-        {
-          {arifle_TRG21_GL_F,
-            {optic_Holosight_khk_F,acc_pointer_IR,30Rnd_556x45_Stanag,1Rnd_HE_Grenade_shell}
-          },
-          {arifle_TRG21_GL_F,
-            {optic_MRCO,acc_pointer_IR,30Rnd_556x45_Stanag,1Rnd_HE_Grenade_shell}
-          },
-          {arifle_Mk20_GL_plain_F,
-            {optic_MRCO,acc_pointer_IR,30Rnd_556x45_Stanag,1Rnd_HE_Grenade_shell}
-          }
-        },
-        Rangefinder
-      };
-		};
-		class RandomisedUnit2: RandomisedUnit {
-			weapons[] = {
-        {arifle_TRG21_GL_F,
-          {optic_Holosight_khk_F,acc_pointer_IR,30Rnd_556x45_Stanag,1Rnd_HE_Grenade_shell}
-        },
-        Rangefinder
-      };
-			vestRandom = 0;
-			vest[] = {V_CarrierRigKBT_01_light_Olive_F};
-		};
-		class ExampleVehicle {
-			vehCargoWeapons[] = {{"launch_NLAW_F",2}};
-			vehCargoMagazines[] = {
-				{"30Rnd_556x45_Stanag",20},
-				{"30Rnd_556x45_Stanag_Tracer_Yellow",20},
-        {"200Rnd_556x45_box_red_f",4},
-        {"200Rnd_556x45_box_tracer_red_f",4},
-				{"HandGrenade",12},
-				{"SmokeShell",12},
-				{"1Rnd_HE_Grenade_shell",20}
-			};
-			vehCargoItems[] = {
-				{"FirstAidKit",15},
-				{"Medikit",1},
-				{"I_UavTerminal",1},
-				{"ToolKit",1}
-			};
-			vehCargoRucks[] = {
-        {"B_Kitbag_rgr",2,{
-           {"30Rnd_556x45_Stanag_red",6},
-           {"30Rnd_556x45_Stanag_Tracer_Red",2},
-           {"HandGrenade",2},
-           {"SmokeShell",2},
-           {"Chemlight_green",2},
-           {"B_IR_Grenade",1},
-           {"200Rnd_556x45_box_red_f",2},
-           {"200Rnd_556x45_box_tracer_red_f",2}
-          }
-        }
-			};
-		};
-		class ExampleVehicle2: ExampleVehicle {
-      vehCargoRucks[] = {
-        {"B_Kitbag_rgr",2,{
-           {"30Rnd_556x45_Stanag_red",6},
-           {"30Rnd_556x45_Stanag_Tracer_Red",2},
-           {"HandGrenade",2},
-           {"SmokeShell",2},
-           {"Chemlight_green",2},
-           {"B_IR_Grenade",1},
-           {"200Rnd_556x45_box_red_f",2},
-           {"200Rnd_556x45_box_tracer_red_f",2}
-          }
-        }
-			};
-		};
-	};
-	#include "toadball_insurgents1.hpp"
+#include "toadball_insurgents1.hpp"
 };

--- a/tb3/toadball_insurgents1.hpp
+++ b/tb3/toadball_insurgents1.hpp
@@ -1,212 +1,193 @@
-	class FIA_INS { 
-		class baseUnit {
-			ace_earplugs = 1;
-			headgearRandom = 1;
-			gogglesRandom = 0;
-			uniformRandom = 1;
-			backpackRandom = 0;
-			vestRandom = 1;			
-			
-			weapons[] = {"rhs_weap_akm"};
-			priKit[] = {};
-			secKit[] = {};
-			pisKit[] = {};
-			
-			assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ace_maptools"};
-			
-			headgear[] = {
-				"H_Watchcap_khk",
-				"H_Watchcap_blk",
-				"H_ShemagOpen_khk",
-				"H_Shemag_olive",
-				"H_Bandanna_gry",
-				"H_Bandanna_sgg",
-				"H_Bandanna_cbr",
-				"H_Bandanna_khk",
-				"H_MilCap_dgtl",
-				"H_MilCap_gry",
-				"H_Cap_grn",
-				"H_Cap_blk",
-				"H_Cap_tan",
-				"H_Booniehat_dgtl",
-				"H_Booniehat_tan",
-				"H_Booniehat_grn",
-				"H_Booniehat_khk"
-			};
-			goggles[] = {};
-			
-			uniform[] = {
-				"U_BG_Guerrilla_6_1",
-				"U_BG_leader",
-				"U_BG_Guerilla3_2",
-				"U_BG_Guerilla2_3",
-				"U_BG_Guerilla2_2",
-				"U_BG_Guerilla2_1",
-				"U_BG_Guerilla1_1"
-			};
-				uniformContents[] = {};
-				
-			vest[] = {
-				"V_Chestrig_oli",
-				"V_Chestrig_blk",
-				"V_Chestrig_rgr",
-				"V_TacVest_oli",
-				"V_TacVest_blk"
-				
-			};
-				vestContents[] = {
-					{"ACE_fieldDressing",2},
-					{"ACE_morphine",1},
-					{"ACE_tourniquet",1},	
-					{"ACE_epinephrine",1},
-					{"ACE_packingBandage",2},
-					{"ACE_quikclot",2},
-					{"ACE_elasticBandage",2},					
-					{"rhs_30Rnd_762x39mm",6},
-					{"rhs_30Rnd_762x39mm_tracer",2},
-					{"HandGrenade",2}
-				};
-				
-			backpack[] = {};
-				backpackContents[] = {};
-				
-			magazines[] = {}; items[] = {};
-		};
-		class InsurgentTL: baseUnit {
-			weapons[] = {"rhs_weap_akms","Binocular"};
-				vestContents[] = {
-					{"ACE_fieldDressing",2},
-					{"ACE_morphine",1},
-					{"ACE_tourniquet",1},	
-					{"ACE_epinephrine",1},
-					{"ACE_packingBandage",2},
-					{"ACE_quikclot",2},
-					{"ACE_elasticBandage",2},					
-					{"rhs_30Rnd_762x39mm",6},
-					{"rhs_30Rnd_762x39mm_tracer",2},
-					{"HandGrenade",2},
-					{"ACRE_PRC152"}
-				};		
-		};	
-		class Insurgent1: baseUnit {
-			weapons[] = {"rhs_weap_akms"};
-		};
-		class Insurgent2: baseUnit {
-			weapons[] = {"rhs_weap_akm"};
-		};		
-		class InsurgentGL1: baseUnit {
-			weapons[] = {"rhs_weap_akms_gp25"};
-				vestContents[] = {
-					{"ACE_fieldDressing",2},
-					{"ACE_morphine",1},
-					{"ACE_tourniquet",1},	
-					{"ACE_epinephrine",1},
-					{"ACE_packingBandage",2},
-					{"ACE_quikclot",2},
-					{"ACE_elasticBandage",2},					
-					{"rhs_30Rnd_762x39mm",4},
-					{"rhs_30Rnd_762x39mm_tracer",2},
-					{"HandGrenade",2},
-					{"rhs_VOG25",10}
-				};				
-		};
-		class InsurgentGL2: InsurgentGL1 {
-			weapons[] = {"rhs_weap_akm_gp25"};			
-		};		
-		class InsurgentMG: baseUnit {
-			weapons[] = {"rhs_weap_pkm"};
-			priKit[] = {"rhs_100Rnd_762x54mmR"};
-				vestContents[] = {
-					{"ACE_fieldDressing",2},
-					{"ACE_morphine",1},
-					{"ACE_tourniquet",1},	
-					{"ACE_epinephrine",1},
-					{"ACE_packingBandage",2},
-					{"ACE_quikclot",2},
-					{"ACE_elasticBandage",2},					
-					{"rhs_100Rnd_762x54mmR",1},
-					{"rhs_100Rnd_762x54mmR_green",1},
-					{"HandGrenade",2}
-				};				
-		};	
-		class InsurgentMM: baseUnit {
-			weapons[] = {"rhs_weap_svd"};
-			priKit[] = {"rhs_acc_pso1m2"};
-				vestContents[] = {
-					{"ACE_fieldDressing",2},
-					{"ACE_morphine",1},
-					{"ACE_tourniquet",1},	
-					{"ACE_epinephrine",1},
-					{"ACE_packingBandage",2},
-					{"ACE_quikclot",2},
-					{"ACE_elasticBandage",2},					
-					{"rhs_10Rnd_762x54mmR_7N1",8},
-					{"HandGrenade",2}
-				};				
-		};		
+    class FIA_INS { 
+        class baseUnit {
+            ace_earplugs = 1;	
+            
+            weapons[] = {"rhs_weap_akm"};
+            priKit[] = {};
+            secKit[] = {};
+            pisKit[] = {};
+            
+            assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ace_maptools"};
+            
+            headgear[] = {
+                "H_Watchcap_khk",
+                "H_Watchcap_blk",
+                "H_ShemagOpen_khk",
+                "H_Shemag_olive",
+                "H_Bandanna_gry",
+                "H_Bandanna_sgg",
+                "H_Bandanna_cbr",
+                "H_Bandanna_khk",
+                "H_MilCap_dgtl",
+                "H_MilCap_gry",
+                "H_Cap_grn",
+                "H_Cap_blk",
+                "H_Cap_tan",
+                "H_Booniehat_dgtl",
+                "H_Booniehat_tan",
+                "H_Booniehat_grn",
+                "H_Booniehat_khk"
+            };
+            goggles[] = {};
+            
+            uniform[] = {
+                "U_BG_Guerrilla_6_1",
+                "U_BG_leader",
+                "U_BG_Guerilla3_2",
+                "U_BG_Guerilla2_3",
+                "U_BG_Guerilla2_2",
+                "U_BG_Guerilla2_1",
+                "U_BG_Guerilla1_1"
+            };
+            uniformContents[] = {};
+                
+            vest[] = {
+                "V_Chestrig_oli",
+                "V_Chestrig_blk",
+                "V_Chestrig_rgr",
+                "V_TacVest_oli",
+                "V_TacVest_blk"
+                
+            };
+            vestContents[] = {
+                {"ACE_fieldDressing",2},
+                {"ACE_morphine",1},
+                {"ACE_tourniquet",1},	
+                {"ACE_epinephrine",1},
+                {"ACE_packingBandage",2},
+                {"ACE_quikclot",2},
+                {"ACE_elasticBandage",2},					
+                {"rhs_30Rnd_762x39mm",6},
+                {"rhs_30Rnd_762x39mm_tracer",2},
+                {"HandGrenade",2}
+            };
+                
+            backpack[] = {};
+            backpackContents[] = {};
+        };
+        class InsurgentTL: baseUnit {
+            weapons[] = {"rhs_weap_akms","Binocular"};
+            vestContents[] = {
+                {"ACE_fieldDressing",2},
+                {"ACE_morphine",1},
+                {"ACE_tourniquet",1},	
+                {"ACE_epinephrine",1},
+                {"ACE_packingBandage",2},
+                {"ACE_quikclot",2},
+                {"ACE_elasticBandage",2},					
+                {"rhs_30Rnd_762x39mm",6},
+                {"rhs_30Rnd_762x39mm_tracer",2},
+                {"HandGrenade",2},
+                {"ACRE_PRC152"}
+            };		
+        };	
+        class Insurgent1: baseUnit {
+            weapons[] = {"rhs_weap_akms"};
+        };
+        class Insurgent2: baseUnit {
+            weapons[] = {"rhs_weap_akm"};
+        };		
+        class InsurgentGL1: baseUnit {
+            weapons[] = {"rhs_weap_akms_gp25"};
+            vestContents[] = {
+                {"ACE_fieldDressing",2},
+                {"ACE_morphine",1},
+                {"ACE_tourniquet",1},	
+                {"ACE_epinephrine",1},
+                {"ACE_packingBandage",2},
+                {"ACE_quikclot",2},
+                {"ACE_elasticBandage",2},					
+                {"rhs_30Rnd_762x39mm",4},
+                {"rhs_30Rnd_762x39mm_tracer",2},
+                {"HandGrenade",2},
+                {"rhs_VOG25",10}
+            };				
+        };
+        class InsurgentGL2: InsurgentGL1 {
+            weapons[] = {"rhs_weap_akm_gp25"};			
+        };		
+        class InsurgentMG: baseUnit {
+            weapons[] = {"rhs_weap_pkm"};
+            priKit[] = {"rhs_100Rnd_762x54mmR"};
+            vestContents[] = {
+                {"ACE_fieldDressing",2},
+                {"ACE_morphine",1},
+                {"ACE_tourniquet",1},	
+                {"ACE_epinephrine",1},
+                {"ACE_packingBandage",2},
+                {"ACE_quikclot",2},
+                {"ACE_elasticBandage",2},					
+                {"rhs_100Rnd_762x54mmR",1},
+                {"rhs_100Rnd_762x54mmR_green",1},
+                {"HandGrenade",2}
+            };				
+        };	
+        class InsurgentMM: baseUnit {
+            weapons[] = {"rhs_weap_svd"};
+            priKit[] = {"rhs_acc_pso1m2"};
+            vestContents[] = {
+                {"ACE_fieldDressing",2},
+                {"ACE_morphine",1},
+                {"ACE_tourniquet",1},	
+                {"ACE_epinephrine",1},
+                {"ACE_packingBandage",2},
+                {"ACE_quikclot",2},
+                {"ACE_elasticBandage",2},					
+                {"rhs_10Rnd_762x54mmR_7N1",8},
+                {"HandGrenade",2}
+            };				
+        };		
 
-		//apply these to rucksacks placed on the ground
-		class AMMObackpack {
-			//vehCargoWeapons[] = { };
-			vehCargoMagazines[] = {
-				{"rhs_30Rnd_762x39mm",4},
-				{"rhs_30Rnd_762x39mm_tracer",1},
-				{"rhs_100Rnd_762x54mmR_green",1},
-				{"HandGrenade",2},
-				{"SmokeShell",2}
-			};
-			/*
-			vehCargoItems[] = {
-				{"ACE_Cellphone",1},
-				{"ACE_DefusalKit",1}
-			};
-			
-			vehCargoRucks[] = {
-				{"B_Kitbag_sgg",15}
-			};
-			*/
-		};
-		class MGbackpack {
-			vehCargoWeapons[] = { };
-			vehCargoMagazines[] = {
-				{"rhs_100Rnd_762x54mmR",2},
-				{"rhs_100Rnd_762x54mmR_green",1}
-			};
+        //apply these to rucksacks placed on the ground
+        class AMMObackpack {
+            vehCargoMagazines[] = {
+                {"rhs_30Rnd_762x39mm",4},
+                {"rhs_30Rnd_762x39mm_tracer",1},
+                {"rhs_100Rnd_762x54mmR_green",1},
+                {"HandGrenade",2},
+                {"SmokeShell",2}
+            };
+        };
+        class MGbackpack {
+            vehCargoWeapons[] = { };
+            vehCargoMagazines[] = {
+                {"rhs_100Rnd_762x54mmR",2},
+                {"rhs_100Rnd_762x54mmR_green",1}
+            };
 
-			vehCargoItems[] = {};
-			vehCargoRucks[] = {};
-		};	
-		class IEDbackpack {
-			vehCargoWeapons[] = { };
-			vehCargoMagazines[] = {
-				{"IEDLandSmall_Remote_Mag",2},
-				{"IEDLandBig_Remote_Mag",1}
-			};
-			vehCargoItems[] = {
-				{"ACE_Cellphone",1},
-				{"ACE_DefusalKit",1}
-			};
-			vehCargoRucks[] = {};
-		};		
-		class MEDbackpack {
-			vehCargoWeapons[] = {};
-			vehCargoMagazines[] = {
-				{"SmokeShellYellow",2},
-				{"SmokeShellGreen",2}			
-			};
-			vehCargoItems[] = {
-				{"ACE_fieldDressing",20},
-				{"ACE_packingBandage",20},
-				{"ACE_quikclot",20},
-				{"ACE_elasticBandage",20},
-				{"ACE_morphine",20},
-				{"ACE_epinephrine",20},
-				{"ACE_salineIV",5},
-				{"ACE_personalAidKit",3},
-				{"ACE_surgicalKit",3},
-				{"ACE_tourniquet",5}			
-			};
-			vehCargoRucks[] = {};
-		};	
-
-	};
+            vehCargoItems[] = {};
+            vehCargoRucks[] = {};
+        };	
+        class IEDbackpack {
+            vehCargoWeapons[] = { };
+            vehCargoMagazines[] = {
+                {"IEDLandSmall_Remote_Mag",2},
+                {"IEDLandBig_Remote_Mag",1}
+            };
+            vehCargoItems[] = {
+                {"ACE_Cellphone",1},
+                {"ACE_DefusalKit",1}
+            };
+            vehCargoRucks[] = {};
+        };		
+        class MEDbackpack {
+            vehCargoWeapons[] = {};
+            vehCargoMagazines[] = {
+                {"SmokeShellYellow",2},
+                {"SmokeShellGreen",2}			
+            };
+            vehCargoItems[] = {
+                {"ACE_fieldDressing",20},
+                {"ACE_packingBandage",20},
+                {"ACE_quikclot",20},
+                {"ACE_elasticBandage",20},
+                {"ACE_morphine",20},
+                {"ACE_epinephrine",20},
+                {"ACE_salineIV",5},
+                {"ACE_personalAidKit",3},
+                {"ACE_surgicalKit",3},
+                {"ACE_tourniquet",5}			
+            };
+            vehCargoRucks[] = {};
+        };	
+    };

--- a/tb3/toadball_insurgents2.hpp
+++ b/tb3/toadball_insurgents2.hpp
@@ -1,230 +1,211 @@
-	class TB_FIA_INS { 
-		class baseUnit {
-			ace_earplugs = 1;
-			headgearRandom = 1;
-			gogglesRandom = 0;
-			uniformRandom = 1;
-			backpackRandom = 0;
-			vestRandom = 1;			
-			
-			weapons[] = {"rhs_weap_akm"};
-			priKit[] = {};
-			secKit[] = {};
-			pisKit[] = {};
-			
-			assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ace_maptools"};
-			
-			headgear[] = {
-				"H_Watchcap_khk",
-				"H_Watchcap_blk",
-				"H_ShemagOpen_khk",
-				"H_Shemag_olive",
-				"H_Bandanna_gry",
-				"H_Bandanna_sgg",
-				"H_Bandanna_cbr",
-				"H_Bandanna_khk",
-				"H_MilCap_dgtl",
-				"H_MilCap_gry",
-				"H_Cap_grn",
-				"H_Cap_blk",
-				"H_Cap_tan",
-				"H_Booniehat_dgtl",
-				"H_Booniehat_tan",
-				"H_Booniehat_grn",
-				"H_Booniehat_khk"
-			};
-			goggles[] = {};
-			
-			uniform[] = {
-				"U_BG_Guerrilla_6_1",
-				"U_BG_leader",
-				"U_BG_Guerilla3_2",
-				"U_BG_Guerilla2_3",
-				"U_BG_Guerilla2_2",
-				"U_BG_Guerilla2_1",
-				"U_BG_Guerilla1_1"
-			};
-				uniformContents[] = {};
-				
-			vest[] = {
-				"V_Chestrig_oli",
-				"V_Chestrig_blk",
-				"V_Chestrig_rgr",
-			};
-				vestContents[] = {
-					{"ACE_fieldDressing",2},
-					{"ACE_tourniquet",2},	
-					{"ACE_packingBandage",2},
-					{"ACE_quikclot",2},
-					{"ACE_elasticBandage",2},					
-					{"rhs_30Rnd_762x39mm",6},
-					{"rhs_30Rnd_762x39mm_tracer",2},
-					{"HandGrenade",2}
-				};
-				
-			backpack[] = {};
-				backpackContents[] = {};
-				
-			magazines[] = {}; items[] = {};
-		};
-		class InsurgentSL1: baseUnit {
-				uniformContents[] = {{"ACRE_PRC343",1},{"ACE_Cellphone",1}};
-			weapons[] = {"rhs_weap_akms","Binocular"};	
-			backpackRandom = 1;
-			backpack[] = {
-				"B_FieldPack_khk",
-				"B_FieldPack_cbr",
-				"B_FieldPack_oli"
-			};
-				backpackContents[] = {{"ACRE_PRC77",1}};			
-		};
-		class InsurgentSL2: InsurgentSL1 {
-			weapons[] = {"rhs_weap_akm","Binocular"};			
-		};
-		class InsurgentTL1: baseUnit {
-				uniformContents[] = {{"ACRE_PRC343",1}};
-			weapons[] = {"rhs_weap_akms","Binocular"};		
-		};
-		class InsurgentTL2: InsurgentTL1 {
-			weapons[] = {"rhs_weap_akm","Binocular"};		
-		};	
-		class Insurgent1: baseUnit {
-			weapons[] = {"rhs_weap_akms"};
-		};
-		class Insurgent2: baseUnit {
-			weapons[] = {"rhs_weap_akm"};
-		};		
-		class InsurgentGL1: baseUnit {
-			weapons[] = {"rhs_weap_akms_gp25"};
-				vestContents[] = {
-					{"ACE_fieldDressing",2},
-					{"ACE_tourniquet",2},	
-					{"ACE_packingBandage",2},
-					{"ACE_quikclot",2},
-					{"ACE_elasticBandage",2},					
-					{"rhs_30Rnd_762x39mm",4},
-					{"rhs_30Rnd_762x39mm_tracer",2},
-					{"HandGrenade",2},
-					{"rhs_VOG25",10}
-				};				
-		};
-		class InsurgentGL2: InsurgentGL1 {
-			weapons[] = {"rhs_weap_akm_gp25"};			
-		};		
-		class InsurgentMG: baseUnit {
-			weapons[] = {"rhs_weap_pkm"};
-			priKit[] = {"rhs_100Rnd_762x54mmR"};
-				vestContents[] = {
-					{"ACE_fieldDressing",2},
-					{"ACE_tourniquet",2},	
-					{"ACE_packingBandage",2},
-					{"ACE_quikclot",2},
-					{"ACE_elasticBandage",2},					
-					{"rhs_100Rnd_762x54mmR",1},
-					{"rhs_100Rnd_762x54mmR_green",1},
-					{"HandGrenade",2}
-				};				
-		};	
-		class InsurgentMM: baseUnit {
-			weapons[] = {"rhs_weap_svd"};
-			priKit[] = {"rhs_acc_pso1m2"};
-				vestContents[] = {
-					{"ACE_fieldDressing",2},
-					{"ACE_tourniquet",2},	
-					{"ACE_packingBandage",2},
-					{"ACE_quikclot",2},
-					{"ACE_elasticBandage",2},					
-					{"rhs_10Rnd_762x54mmR_7N1",8},
-					{"HandGrenade",2}
-				};				
-		};		
-		class InsurgentMED: baseUnit {
-				uniformContents[] = {{"ACRE_PRC343",1}};		
-			backpackRandom = 1;
-			backpack[] = {
-				"B_FieldPack_khk",
-				"B_FieldPack_cbr",
-				"B_FieldPack_blk",
-				"B_FieldPack_oli"
-			};
-			backpackContents[] = {
-				{"SmokeShellYellow",2},
-				{"SmokeShellGreen",2},
-				{"ACE_fieldDressing",20},
-				{"ACE_packingBandage",20},
-				{"ACE_quikclot",20},
-				{"ACE_elasticBandage",20},
-				{"ACE_morphine",20},
-				{"ACE_epinephrine",20},
-				{"ACE_salineIV",5},
-				{"ACE_personalAidKit",3},
-				{"ACE_surgicalKit",3},
-				{"ACE_tourniquet",5}
-			};			
-		};		
-		//apply these to rucksacks placed on the ground
-		class AMMObackpack {
-			//vehCargoWeapons[] = { };
-			vehCargoMagazines[] = {
-				{"rhs_30Rnd_762x39mm",4},
-				{"rhs_30Rnd_762x39mm_tracer",1},
-				{"rhs_100Rnd_762x54mmR_green",1},
-				{"HandGrenade",2},
-				{"SmokeShell",2}
-			};
-			/*
-			vehCargoItems[] = {
-				{"ACE_Cellphone",1},
-				{"ACE_DefusalKit",1}
-			};
-			
-			vehCargoRucks[] = {
-				{"B_Kitbag_sgg",15}
-			};
-			*/
-		};
-		class MGbackpack {
-			vehCargoWeapons[] = { };
-			vehCargoMagazines[] = {
-				{"rhs_100Rnd_762x54mmR",2},
-				{"rhs_100Rnd_762x54mmR_green",1}
-			};
+    class TB_FIA_INS { 
+        class baseUnit {
+            ace_earplugs = 1;	
+            
+            weapons[] = {"rhs_weap_akm"};
+            priKit[] = {};
+            secKit[] = {};
+            pisKit[] = {};
+            
+            assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ace_maptools"};
+            
+            headgear[] = {
+                "H_Watchcap_khk",
+                "H_Watchcap_blk",
+                "H_ShemagOpen_khk",
+                "H_Shemag_olive",
+                "H_Bandanna_gry",
+                "H_Bandanna_sgg",
+                "H_Bandanna_cbr",
+                "H_Bandanna_khk",
+                "H_MilCap_dgtl",
+                "H_MilCap_gry",
+                "H_Cap_grn",
+                "H_Cap_blk",
+                "H_Cap_tan",
+                "H_Booniehat_dgtl",
+                "H_Booniehat_tan",
+                "H_Booniehat_grn",
+                "H_Booniehat_khk"
+            };
+            goggles[] = {};
+            
+            uniform[] = {
+                "U_BG_Guerrilla_6_1",
+                "U_BG_leader",
+                "U_BG_Guerilla3_2",
+                "U_BG_Guerilla2_3",
+                "U_BG_Guerilla2_2",
+                "U_BG_Guerilla2_1",
+                "U_BG_Guerilla1_1"
+            };
+                uniformContents[] = {};
+                
+            vest[] = {
+                "V_Chestrig_oli",
+                "V_Chestrig_blk",
+                "V_Chestrig_rgr",
+            };
+            vestContents[] = {
+                {"ACE_fieldDressing",2},
+                {"ACE_tourniquet",2},	
+                {"ACE_packingBandage",2},
+                {"ACE_quikclot",2},
+                {"ACE_elasticBandage",2},					
+                {"rhs_30Rnd_762x39mm",6},
+                {"rhs_30Rnd_762x39mm_tracer",2},
+                {"HandGrenade",2}
+            };
+                
+            backpack[] = {};
+            backpackContents[] = {};
+        };
+        class InsurgentSL1: baseUnit {
+            uniformContents[] = {{"ACRE_PRC343",1},{"ACE_Cellphone",1}};
+            weapons[] = {"rhs_weap_akms","Binocular"};
+            backpack[] = {
+                "B_FieldPack_khk",
+                "B_FieldPack_cbr",
+                "B_FieldPack_oli"
+            };
+            backpackContents[] = {{"ACRE_PRC77",1}};			
+        };
+        class InsurgentSL2: InsurgentSL1 {
+            weapons[] = {"rhs_weap_akm","Binocular"};			
+        };
+        class InsurgentTL1: baseUnit {
+            uniformContents[] = {{"ACRE_PRC343",1}};
+            weapons[] = {"rhs_weap_akms","Binocular"};		
+        };
+        class InsurgentTL2: InsurgentTL1 {
+            weapons[] = {"rhs_weap_akm","Binocular"};		
+        };	
+        class Insurgent1: baseUnit {
+            weapons[] = {"rhs_weap_akms"};
+        };
+        class Insurgent2: baseUnit {
+            weapons[] = {"rhs_weap_akm"};
+        };		
+        class InsurgentGL1: baseUnit {
+            weapons[] = {"rhs_weap_akms_gp25"};
+            vestContents[] = {
+                {"ACE_fieldDressing",2},
+                {"ACE_tourniquet",2},	
+                {"ACE_packingBandage",2},
+                {"ACE_quikclot",2},
+                {"ACE_elasticBandage",2},					
+                {"rhs_30Rnd_762x39mm",4},
+                {"rhs_30Rnd_762x39mm_tracer",2},
+                {"HandGrenade",2},
+                {"rhs_VOG25",10}
+            };				
+        };
+        class InsurgentGL2: InsurgentGL1 {
+            weapons[] = {"rhs_weap_akm_gp25"};			
+        };		
+        class InsurgentMG: baseUnit {
+            weapons[] = {"rhs_weap_pkm"};
+            priKit[] = {"rhs_100Rnd_762x54mmR"};
+            vestContents[] = {
+                {"ACE_fieldDressing",2},
+                {"ACE_tourniquet",2},	
+                {"ACE_packingBandage",2},
+                {"ACE_quikclot",2},
+                {"ACE_elasticBandage",2},					
+                {"rhs_100Rnd_762x54mmR",1},
+                {"rhs_100Rnd_762x54mmR_green",1},
+                {"HandGrenade",2}
+            };				
+        };	
+        class InsurgentMM: baseUnit {
+            weapons[] = {"rhs_weap_svd"};
+            priKit[] = {"rhs_acc_pso1m2"};
+            vestContents[] = {
+                {"ACE_fieldDressing",2},
+                {"ACE_tourniquet",2},	
+                {"ACE_packingBandage",2},
+                {"ACE_quikclot",2},
+                {"ACE_elasticBandage",2},					
+                {"rhs_10Rnd_762x54mmR_7N1",8},
+                {"HandGrenade",2}
+            };				
+        };		
+        class InsurgentMED: baseUnit {
+            uniformContents[] = {{"ACRE_PRC343",1}};		
+            backpackRandom = 1;
+            backpack[] = {
+                "B_FieldPack_khk",
+                "B_FieldPack_cbr",
+                "B_FieldPack_blk",
+                "B_FieldPack_oli"
+            };
+            backpackContents[] = {
+                {"SmokeShellYellow",2},
+                {"SmokeShellGreen",2},
+                {"ACE_fieldDressing",20},
+                {"ACE_packingBandage",20},
+                {"ACE_quikclot",20},
+                {"ACE_elasticBandage",20},
+                {"ACE_morphine",20},
+                {"ACE_epinephrine",20},
+                {"ACE_salineIV",5},
+                {"ACE_personalAidKit",3},
+                {"ACE_surgicalKit",3},
+                {"ACE_tourniquet",5}
+            };			
+        };		
+        //apply these to rucksacks placed on the ground
+        class AMMObackpack {
+            vehCargoMagazines[] = {
+                {"rhs_30Rnd_762x39mm",4},
+                {"rhs_30Rnd_762x39mm_tracer",1},
+                {"rhs_100Rnd_762x54mmR_green",1},
+                {"HandGrenade",2},
+                {"SmokeShell",2}
+            };
+        };
+        class MGbackpack {
+            vehCargoWeapons[] = { };
+            vehCargoMagazines[] = {
+                {"rhs_100Rnd_762x54mmR",2},
+                {"rhs_100Rnd_762x54mmR_green",1}
+            };
 
-			vehCargoItems[] = {};
-			vehCargoRucks[] = {};
-		};	
-		class IEDbackpack {
-			vehCargoWeapons[] = { };
-			vehCargoMagazines[] = {
-				{"DemoCharge_Remote_Mag",5},
-				{"IEDLandBig_Remote_Mag",1}
-			};
-			vehCargoItems[] = {
-				{"ACE_Clacker",2},
-				{"ACE_Cellphone",1},
-				{"ACE_DefusalKit",1}
-			};
-			vehCargoRucks[] = {};
-		};		
-		class MEDbackpack {
-			vehCargoWeapons[] = {};
-			vehCargoMagazines[] = {
-				{"SmokeShellYellow",2},
-				{"SmokeShellGreen",2}			
-			};
-			vehCargoItems[] = {
-				{"ACE_fieldDressing",20},
-				{"ACE_packingBandage",20},
-				{"ACE_quikclot",20},
-				{"ACE_elasticBandage",20},
-				{"ACE_morphine",20},
-				{"ACE_epinephrine",20},
-				{"ACE_salineIV",5},
-				{"ACE_personalAidKit",3},
-				{"ACE_surgicalKit",3},
-				{"ACE_tourniquet",5}			
-			};
-			vehCargoRucks[] = {};
-		};	
+            vehCargoItems[] = {};
+            vehCargoRucks[] = {};
+        };	
+        class IEDbackpack {
+            vehCargoWeapons[] = { };
+            vehCargoMagazines[] = {
+                {"DemoCharge_Remote_Mag",5},
+                {"IEDLandBig_Remote_Mag",1}
+            };
+            vehCargoItems[] = {
+                {"ACE_Clacker",2},
+                {"ACE_Cellphone",1},
+                {"ACE_DefusalKit",1}
+            };
+            vehCargoRucks[] = {};
+        };		
+        class MEDbackpack {
+            vehCargoWeapons[] = {};
+            vehCargoMagazines[] = {
+                {"SmokeShellYellow",2},
+                {"SmokeShellGreen",2}			
+            };
+            vehCargoItems[] = {
+                {"ACE_fieldDressing",20},
+                {"ACE_packingBandage",20},
+                {"ACE_quikclot",20},
+                {"ACE_elasticBandage",20},
+                {"ACE_morphine",20},
+                {"ACE_epinephrine",20},
+                {"ACE_salineIV",5},
+                {"ACE_personalAidKit",3},
+                {"ACE_surgicalKit",3},
+                {"ACE_tourniquet",5}			
+            };
+            vehCargoRucks[] = {};
+        };	
 
-	};
+    };


### PR DESCRIPTION
This PR adds the missing quotation marks around classnames in loadout.hpp and I fixed the formatting overall while I was at it.