### PR TITLE
Add more*[] arrays for weapons and container contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Once enabled, additional classes should be added to the appropriate loadout vari
 
 These arrays can be added to a loadout inheriting from another loadout, which allows the loadout to add weapons or items without having to duplicate the `weapons[]` and `*contents[]` arrays of the parent.
 
-`moreWeapon[]`, `moreUniformContents[]`, `moreVestContents[]`, and `moreBackpackContents[]` are supported.
+`moreWeapons[]`, `moreUniformContents[]`, `moreVestContents[]`, and `moreBackpackContents[]` are supported.
 
 Example:
 ```cpp

--- a/README.md
+++ b/README.md
@@ -223,6 +223,28 @@ How this can be done is detailed along with how to set these as normal.
 
 Once enabled, additional classes should be added to the appropriate loadout variable. Additionally, this will disable the ability for you to clear the inventories of rucksacks prior to adding them to a unit.
 
+#### More*[] arrays
+
+These arrays can be added to a loadout inheriting from another loadout, which allows the loadout to add weapons or items without having to duplicate the `weapons[]` and `*contents[]` arrays of the parent.
+
+`moreWeapon[]`, `moreUniformContents[]`, `moreVestContents[]`, and `moreBackpackContents[]` are supported.
+
+Example:
+```cpp
+class Rifleman {
+  weapons[] = {LOADS_OF_RANDOM_RIFLES};
+  vestContents[] = {
+    MAGAZINES,
+    GRENADES,
+    BANDAGES
+};
+
+class TeamLeader: Rifleman {
+  moreWeapons[] = {BINOCULARS};
+  moreVestContents[] = {RADIO};
+};
+```
+
 
 ### Vehicle/Object Inventory Specific variables:
 

--- a/tb3/f/gear/fLoadout.sqf
+++ b/tb3/f/gear/fLoadout.sqf
@@ -25,7 +25,7 @@ switch (_mode) do {
   };
 };
 
-private _weapons = getArray (TB3_GearPath >> _cfg >> _gear >> "weapons");
+private _weapons = getArray (TB3_GearPath >> _cfg >> _gear >> "weapons") + getArray (TB3_GearPath >> _cfg >> _gear >> "moreWeapons");
 private _magazines = getArray (TB3_GearPath >> _cfg >> _gear >> "magazines");
 
 private _priKit = getArray (TB3_GearPath >> _cfg >> _gear >> "priKit");
@@ -33,17 +33,17 @@ private _secKit = getArray (TB3_GearPath >> _cfg >> _gear >> "secKit");
 private _pisKit = getArray (TB3_GearPath >> _cfg >> _gear >> "pisKit");
 
 private _backpack = getArray (TB3_GearPath >> _cfg >> _gear >> "backpack");
-private _backpackContents = getArray (TB3_GearPath >> _cfg >> _gear >> "backpackContents");
+private _backpackContents = getArray (TB3_GearPath >> _cfg >> _gear >> "backpackContents") + getArray (TB3_GearPath >> _cfg >> _gear >> "moreBackpackContents");
 
 private _gunbagWeapon = getArray (TB3_GearPath >> _cfg >> _gear >> "ace_gunbagWeapon");
 
 private _headgear = getArray (TB3_GearPath >> _cfg >> _gear >> "headgear");
 
 private _uniform = getArray (TB3_GearPath >> _cfg >> _gear >> "uniform");
-private _uniformContents = getArray (TB3_GearPath >> _cfg >> _gear >> "uniformContents");
+private _uniformContents = getArray (TB3_GearPath >> _cfg >> _gear >> "uniformContents") + getArray (TB3_GearPath >> _cfg >> _gear >> "moreUniformContents");
 
 private _vest = getArray (TB3_GearPath >> _cfg >> _gear >> "vest");
-private _vestContents = getArray (TB3_GearPath >> _cfg >> _gear >> "vestContents");
+private _vestContents = getArray (TB3_GearPath >> _cfg >> _gear >> "vestContents") + getArray (TB3_GearPath >> _cfg >> _gear >> "moreVestContents");
 
 private _goggles = getArray (TB3_GearPath >> _cfg >> _gear >> "goggles");
 private _playerGoggles = goggles _unit;

--- a/tb3/f/gear/fValidateLoadout.sqf
+++ b/tb3/f/gear/fValidateLoadout.sqf
@@ -54,11 +54,11 @@ private _validateGear = {
   private _invalidLoadouts = [];
   
   private _uniform          = getArray (_loadoutConfig >> "uniform");
-  private _uniformContents  = getArray (_loadoutConfig >> "uniformContents");
+  private _uniformContents  = getArray (_loadoutConfig >> "uniformContents") + getArray (_loadoutConfig >> "moreUniformContents");
   private _vest             = getArray (_loadoutConfig >> "vest");
-  private _vestContents     = getArray (_loadoutConfig >> "vestContents");
+  private _vestContents     = getArray (_loadoutConfig >> "vestContents") + getArray (_loadoutConfig >> "moreVestContents");
   private _backpack         = getArray (_loadoutConfig >> "backpack");
-  private _backpackContents = getArray (_loadoutConfig >> "backpackContents");
+  private _backpackContents = getArray (_loadoutConfig >> "backpackContents") + getArray (_loadoutConfig >> "moreBackpackContents");
   
   private _getContentsWeight = {
     params ["_contents"];


### PR DESCRIPTION
Workaround for want of the += operator.

Example:
```cpp
class BaseUnit {
  weapons[] = {LOADS_OF_RANDOM_RIFLES};
  vestContents[] = {
    MAGAZINES,
    GRENADES,
    BANDAGES
};

class TL: BaseUnit {
  moreWeapons[] = {BINOCULARS};
  moreVestContents[] = {RADIO};
};
```